### PR TITLE
Add troubleshooting section for GitHub organization rename

### DIFF
--- a/openhands/usage/troubleshooting/troubleshooting.mdx
+++ b/openhands/usage/troubleshooting/troubleshooting.mdx
@@ -104,3 +104,29 @@ To fix this:
    [sandbox]
    vscode_port = 41234
    ```
+
+### GitHub Organization Rename Issues
+
+**Description**
+
+After the GitHub organization rename from `All-Hands-AI` to `OpenHands`, you may encounter issues with git remotes, Docker images, or broken links.
+
+**Resolution**
+
+* Update your git remote URL:
+  ```bash
+  # Check current remote
+  git remote get-url origin
+  
+  # Update SSH remote
+  git remote set-url origin git@github.com:OpenHands/OpenHands.git
+  
+  # Or update HTTPS remote
+  git remote set-url origin https://github.com/OpenHands/OpenHands.git
+  ```
+* Update Docker image references from `ghcr.io/all-hands-ai/` to `ghcr.io/openhands/`
+* Find and update any hardcoded references:
+  ```bash
+  git grep -i "all-hands-ai"
+  git grep -i "ghcr.io/all-hands-ai"
+  ```


### PR DESCRIPTION
## Description

This PR adds a concise troubleshooting section for issues related to the GitHub organization rename from `All-Hands-AI` to `OpenHands`.

## Changes

- Added new troubleshooting section "GitHub Organization Rename Issues" to the troubleshooting documentation
- Includes step-by-step instructions for updating git remotes (both SSH and HTTPS)
- Covers Docker image reference updates from `ghcr.io/all-hands-ai/` to `ghcr.io/openhands/`
- Provides commands to find and update hardcoded references

## Related Issues

Fixes #3

## References

- Based on information from https://github.com/All-Hands-AI/OpenHands/issues/11376
- Follows the existing format, tone, and length of other troubleshooting items

## Testing

- Verified the troubleshooting section follows the same format as existing entries
- Content is concise and to the point as requested
- Instructions are clear and actionable

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/393d837295f84530840ef3c4604a29e2)